### PR TITLE
fix unjffs2 giving random install errors

### DIFF
--- a/src/OMBManagerInstall.py
+++ b/src/OMBManagerInstall.py
@@ -302,10 +302,7 @@ class OMBManagerInstall(Screen):
 		jffs2_path = src_path + '/jffs2'
 
 		if os.path.exists(OMB_UNJFFS2_BIN):
-			if os.system("%s %s %s" % (OMB_UNJFFS2_BIN, rootfs_path, jffs2_path)) != 0:
-				self.showError(_("Error unpacking rootfs"))
-				rc = False
-
+		        os.system(OMB_UNJFFS2_BIN + ' ' + rootfs_path + ' ' + jffs2_path)
 			if os.path.exists(jffs2_path + '/usr/bin/enigma2'):
 				if os.system(OMB_CP_BIN + ' -rp ' + jffs2_path + '/* ' + dst_path) != 0:
 					self.showError(_("Error copying unpacked rootfs"))


### PR DESCRIPTION
** this happens because unjffs2 command always returns random error messages such as 'file exsists' and 'unhandled inode type' ...etc
i know this may be dangerous but this is the only way to get jffs2 images installed on sh4 receivers!